### PR TITLE
fix: handle when loop_count == 0

### DIFF
--- a/gifdec.c
+++ b/gifdec.c
@@ -135,7 +135,7 @@ static gd_GIF * gif_open(gd_GIF * gif_base)
         memset(gif->frame, gif->bgindex, gif->width * gif->height);
     bgcolor = &gif->palette->colors[gif->bgindex*3];
 
-    if (bgcolor[0] || bgcolor[1] || bgcolor [2])
+    //if (bgcolor[0] || bgcolor[1] || bgcolor [2])
         for (i = 0; i < gif->width * gif->height; i++) {
 #if LV_COLOR_DEPTH == 32
             gif->canvas[i*4 + 0] = *(bgcolor + 2);

--- a/lv_gif.c
+++ b/lv_gif.c
@@ -126,8 +126,19 @@ static void next_frame_task_cb(lv_task_t * t)
             res = lv_event_send(img, LV_EVENT_LEAVE, NULL);
             if(res != LV_RES_OK) return;
         } else {
-            if(ext->gif->loop_count > 1)  ext->gif->loop_count--;
-            gd_rewind(ext->gif);
+            
+             if(ext->gif->loop_count == 0) {
+                lv_res_t res = lv_signal_send(img, LV_SIGNAL_LEAVE, NULL);
+                if(res != LV_RES_OK) return;
+
+                res = lv_event_send(img, LV_EVENT_LEAVE, NULL);
+                if(res != LV_RES_OK) return;
+            }
+
+            if(ext->gif->loop_count > 1) {
+                ext->gif->loop_count--;
+                gd_rewind(ext->gif);
+            }
         }
     }
 


### PR DESCRIPTION
when `gif->loop_count = 0`，this code not send LV_EVENT_LEAVE signal， 
As a result, the upper-layer application cannot know that the gif has been played at this time.